### PR TITLE
Add support for working offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Keep it secret, keep it safe.
 .env
 
+/test_database
+
 #
 # Rust
 #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,12 +162,21 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -244,6 +262,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "heed",
  "reqwest",
  "serde",
  "serde_json",
@@ -273,6 +292,21 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "dashmap"
@@ -306,6 +340,15 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf",
 ]
 
 [[package]]
@@ -493,6 +536,44 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "heed"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4f449bab7320c56003d37732a917e18798e2f1709d80263face2b4f9436ddb"
+dependencies = [
+ "bitflags 2.6.0",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3f528b053a6d700b2734eabcd0fd49cb8230647aa72958467527b0b7917114"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -706,6 +787,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "lmdb-master-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472c3760e2a8d0f61f322fb36788021bb36d573c502b50fa3e2bcaac3ec326c9"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +951,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +988,48 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -942,6 +1086,21 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
@@ -1204,6 +1363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1429,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
 ]
 
 [[package]]
@@ -1672,6 +1846,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.86"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.16", features = ["derive"] }
 dirs = "5.0.1"
+heed = "0.20.5"
 reqwest = { version = "0.12.7", features = ["json"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,59 @@
+use anyhow::{Context, Result};
+use heed::types::SerdeBincode;
+use heed::{Database, EnvOpenOptions};
+
+use crate::Pulse;
+
+pub struct PulseCache {
+    env: heed::Env,
+    database: Database<SerdeBincode<String>, SerdeBincode<Pulse>>,
+}
+
+impl PulseCache {
+    pub fn new() -> Result<Self> {
+        let data_dir = dirs::data_dir().context("no data directory found")?;
+        let database_path = data_dir.join("code-stats-ls/cache");
+
+        std::fs::create_dir_all(&database_path)
+            .context("failed to create cache database directory")?;
+
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(100 * 1024 * 1024)
+                .max_dbs(1)
+                .open(database_path)
+                .context("failed to open cache database")?
+        };
+
+        let mut tx = env.write_txn()?;
+        let database = env.create_database(&mut tx, Some("cache"))?;
+        tx.commit()?;
+
+        Ok(Self { database, env })
+    }
+
+    pub fn list(&self) -> Result<Vec<Pulse>> {
+        let tx = self.env.read_txn()?;
+        let pulses = self
+            .database
+            .iter(&tx)?
+            .filter_map(|entry| entry.ok().map(|(_, pulse)| pulse))
+            .collect::<Vec<_>>();
+
+        Ok(pulses)
+    }
+
+    pub fn save(&self, pulse: &Pulse) -> Result<()> {
+        let mut tx = self.env.write_txn()?;
+        self.database.put(&mut tx, &pulse.coded_at, pulse)?;
+
+        Ok(())
+    }
+
+    pub fn remove(&self, pulse: &Pulse) -> Result<()> {
+        let mut tx = self.env.write_txn()?;
+        self.database.delete(&mut tx, &pulse.coded_at)?;
+
+        Ok(())
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -65,6 +65,7 @@ impl PulseCache {
         Ok(())
     }
 
+    #[cfg(test)]
     pub fn clear(&self) -> Result<()> {
         let mut tx = self.env.write_txn()?;
         self.database.clear(&mut tx)?;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use heed::types::SerdeBincode;
 use heed::{Database, EnvOpenOptions};
@@ -14,6 +16,10 @@ impl PulseCache {
         let data_dir = dirs::data_dir().context("no data directory found")?;
         let database_path = data_dir.join("code-stats-ls/cache");
 
+        Self::from_path(database_path)
+    }
+
+    fn from_path(database_path: impl AsRef<Path>) -> Result<Self> {
         std::fs::create_dir_all(&database_path)
             .context("failed to create cache database directory")?;
 
@@ -46,6 +52,7 @@ impl PulseCache {
     pub fn save(&self, pulse: &Pulse) -> Result<()> {
         let mut tx = self.env.write_txn()?;
         self.database.put(&mut tx, &pulse.coded_at, pulse)?;
+        tx.commit()?;
 
         Ok(())
     }
@@ -53,7 +60,71 @@ impl PulseCache {
     pub fn remove(&self, pulse: &Pulse) -> Result<()> {
         let mut tx = self.env.write_txn()?;
         self.database.delete(&mut tx, &pulse.coded_at)?;
+        tx.commit()?;
 
         Ok(())
+    }
+
+    pub fn clear(&self) -> Result<()> {
+        let mut tx = self.env.write_txn()?;
+        self.database.clear(&mut tx)?;
+        tx.commit()?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Local;
+
+    use crate::PulseXp;
+
+    use super::*;
+
+    #[test]
+    fn test_pulse_cache() {
+        let pulse_cache = PulseCache::from_path("./test_database").unwrap();
+
+        pulse_cache.clear().unwrap();
+
+        let initial_pulses = pulse_cache.list().unwrap();
+        assert_eq!(initial_pulses.len(), 0);
+
+        let first_pulse = Pulse {
+            coded_at: Local::now().to_rfc3339(),
+            xps: vec![PulseXp {
+                language: "Rust".into(),
+                xp: 10,
+            }],
+        };
+
+        pulse_cache.save(&first_pulse).unwrap();
+
+        let pulses = pulse_cache.list().unwrap();
+        assert_eq!(pulses.len(), 1);
+
+        let second_pulse = Pulse {
+            coded_at: Local::now().to_rfc3339(),
+            xps: vec![PulseXp {
+                language: "Gleam".into(),
+                xp: 20,
+            }],
+        };
+
+        pulse_cache.save(&second_pulse).unwrap();
+
+        let pulses = pulse_cache.list().unwrap();
+        assert_eq!(pulses.len(), 2);
+
+        pulse_cache.remove(&second_pulse).unwrap();
+
+        let pulses = pulse_cache.list().unwrap();
+        assert_eq!(pulses.len(), 1);
+
+        pulse_cache.clear().unwrap();
+
+        let pulses = pulse_cache.list().unwrap();
+        assert_eq!(pulses.len(), 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod cache;
 mod config;
 
 use std::collections::HashMap;
@@ -8,21 +9,22 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use chrono::Local;
 use clap::Parser;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tower_lsp::jsonrpc;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
+use crate::cache::PulseCache;
 use crate::config::Config;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct Pulse {
     coded_at: String,
     xps: Vec<PulseXp>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct PulseXp {
     pub language: String,
     pub xp: u32,
@@ -35,10 +37,16 @@ struct CodeStatsLanguageServer {
     client_info: Arc<RwLock<Option<ClientInfo>>>,
     xp_gained_by_language: Arc<Mutex<HashMap<String, u32>>>,
     pulse_tx: mpsc::Sender<()>,
+    pulse_cache: Arc<PulseCache>,
 }
 
 impl CodeStatsLanguageServer {
-    pub fn new(client: Client, config: Config, pulse_tx: mpsc::Sender<()>) -> Self {
+    pub fn new(
+        client: Client,
+        config: Config,
+        pulse_tx: mpsc::Sender<()>,
+        pulse_cache: PulseCache,
+    ) -> Self {
         Self {
             client,
             http_client: reqwest::Client::new(),
@@ -46,6 +54,7 @@ impl CodeStatsLanguageServer {
             client_info: Arc::new(RwLock::new(None)),
             xp_gained_by_language: Arc::new(Mutex::new(HashMap::new())),
             pulse_tx,
+            pulse_cache: Arc::new(pulse_cache),
         }
     }
 
@@ -161,7 +170,56 @@ impl CodeStatsLanguageServer {
         }
     }
 
+    async fn send_cached_pulses(&self) -> Result<()> {
+        let pulses = self.pulse_cache.list()?;
+
+        let mut sent_count = 0;
+
+        for pulse in pulses {
+            match self.send_pulse_internal(&pulse).await {
+                Ok(()) => {
+                    self.pulse_cache.remove(&pulse)?;
+                    sent_count += 1;
+                }
+                Err(err) => {
+                    self.client
+                        .log_message(
+                            MessageType::ERROR,
+                            format!(
+                                "Error sending cached XP pulse from {}: {err}",
+                                pulse.coded_at
+                            ),
+                        )
+                        .await;
+                }
+            }
+        }
+
+        if sent_count > 0 {
+            self.client
+                .log_message(
+                    MessageType::INFO,
+                    format!(
+                        "Sent {sent_count} cached XP pulse{}",
+                        if sent_count == 1 { "" } else { "s" },
+                    ),
+                )
+                .await;
+        }
+
+        Ok(())
+    }
+
     async fn send_pulse(&self) {
+        if let Err(err) = self.send_cached_pulses().await {
+            self.client
+                .log_message(
+                    MessageType::ERROR,
+                    format!("Error sending cached XP pulses: {err}"),
+                )
+                .await;
+        }
+
         let mut xp_gained_by_language = self.xp_gained_by_language.lock().await;
 
         // If we have no XP to gain, no need to send a pulse.
@@ -180,40 +238,42 @@ impl CodeStatsLanguageServer {
                 .collect(),
         };
 
+        self.pulse_cache.save(&pulse).ok();
+
         let mut pulse_url = self.config.api_url.clone();
         pulse_url.set_path("/api/my/pulses");
 
-        match self
-            .http_client
+        match self.send_pulse_internal(&pulse).await {
+            Ok(()) => {
+                self.client
+                    .log_message(MessageType::INFO, "XP pulse sent successfully")
+                    .await;
+
+                self.pulse_cache.remove(&pulse).ok();
+                xp_gained_by_language.clear();
+            }
+            Err(err) => {
+                self.client
+                    .log_message(MessageType::ERROR, format!("Error sending XP pulse: {err}"))
+                    .await;
+            }
+        }
+    }
+
+    async fn send_pulse_internal(&self, pulse: &Pulse) -> Result<()> {
+        let mut pulse_url = self.config.api_url.clone();
+        pulse_url.set_path("/api/my/pulses");
+
+        self.http_client
             .post(pulse_url)
             .header("User-Agent", self.user_agent().await)
             .header("X-API-Token", &self.config.api_token)
             .json(&pulse)
             .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status().is_success() {
-                    self.client
-                        .log_message(MessageType::INFO, "XP pulse sent successfully")
-                        .await;
+            .await?
+            .error_for_status()?;
 
-                    xp_gained_by_language.clear();
-                } else {
-                    self.client
-                        .log_message(MessageType::ERROR, "Failed to send XP pulse")
-                        .await;
-                }
-            }
-            Err(err) => {
-                self.client
-                    .log_message(
-                        MessageType::ERROR,
-                        format!("Error sending XP pulse: {}", err),
-                    )
-                    .await;
-            }
-        }
+        Ok(())
     }
 }
 
@@ -284,10 +344,18 @@ async fn main() -> Result<()> {
     let stdout = tokio::io::stdout();
 
     let (pulse_tx, mut pulse_rx) = mpsc::channel::<()>(100);
+    let pulse_cache = PulseCache::new()?;
 
     let (service, socket) = LspService::new({
         let pulse_tx = pulse_tx.clone();
-        |client| Arc::new(CodeStatsLanguageServer::new(client, config, pulse_tx))
+        |client| {
+            Arc::new(CodeStatsLanguageServer::new(
+                client,
+                config,
+                pulse_tx,
+                pulse_cache,
+            ))
+        }
     });
 
     // Spawn a task to periodically flush any pending XP in the queue.

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,8 @@ impl CodeStatsLanguageServer {
                         .await;
                 }
             }
+
+            tokio::time::sleep(Duration::from_millis(250)).await;
         }
 
         if sent_count > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,6 +266,7 @@ impl CodeStatsLanguageServer {
 
         self.http_client
             .post(pulse_url)
+            .timeout(Duration::from_secs(10))
             .header("User-Agent", self.user_agent().await)
             .header("X-API-Token", &self.config.api_token)
             .json(&pulse)

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,8 +231,6 @@ impl CodeStatsLanguageServer {
                 .collect(),
         };
 
-        self.pulse_cache.save(&pulse).ok();
-
         let mut pulse_url = self.config.api_url.clone();
         pulse_url.set_path("/api/my/pulses");
 
@@ -242,10 +240,11 @@ impl CodeStatsLanguageServer {
                     .log_message(MessageType::INFO, "XP pulse sent successfully")
                     .await;
 
-                self.pulse_cache.remove(&pulse).ok();
                 xp_gained_by_language.clear();
             }
             Err(err) => {
+                self.pulse_cache.save(&pulse).ok();
+
                 self.client
                     .log_message(MessageType::ERROR, format!("Error sending XP pulse: {err}"))
                     .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,8 +239,6 @@ impl CodeStatsLanguageServer {
                 self.client
                     .log_message(MessageType::INFO, "XP pulse sent successfully")
                     .await;
-
-                xp_gained_by_language.clear();
             }
             Err(err) => {
                 self.pulse_cache.save(&pulse).ok();
@@ -250,6 +248,8 @@ impl CodeStatsLanguageServer {
                     .await;
             }
         }
+
+        xp_gained_by_language.clear();
     }
 
     async fn send_pulse_internal(&self, pulse: &Pulse) -> Result<()> {


### PR DESCRIPTION
This PR adds support for working offline.

When the Code::Stats server is unable to be reached—such as when offline—the pulses are persisted to disk.

We then periodically try to flush the cache and send the events up to the server.